### PR TITLE
NTI-9628 add hook to register page generators

### DIFF
--- a/src/get-pageinfo.js
+++ b/src/get-pageinfo.js
@@ -33,7 +33,6 @@ async function generatePageInfoFrom (ntiid, service, context, extras) {
 
 	if (targetPageInfo) { return targetPageInfo; }
 
-	debugger;//eslint-disable-line
 	const generator = RegisteredGenerators[object.MimeType] || GENERATORS[object.MimeType];
 
 	if (!generator) {


### PR DESCRIPTION
Allow external page generators to be registered, so different contents can be parsed using other tools without polluting this lib